### PR TITLE
MinifyCss is now a property on  WebOptimazerScssOptions class.

### DIFF
--- a/src/PipelineExtensions.cs
+++ b/src/PipelineExtensions.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Extensions.DependencyInjection
                            .Concatenate()
                            .FingerprintUrls()
                            .AddResponseHeader("X-Content-Type-Options", "nosniff")
-                           .MinifyCss();
+                           .minifyCssWithOptions(options);
         }
 
         public static IAsset AddScssBundle(this IAssetPipeline pipeline, string route, params string[] sourceFiles)
@@ -64,7 +64,7 @@ namespace Microsoft.Extensions.DependencyInjection
                            .CompileScss(options)
                            .FingerprintUrls()
                            .AddResponseHeader("X-Content-Type-Options", "nosniff")
-                           .MinifyCss();
+                           .minifyCssWithOptions(options);
         }
 
         /// <summary>
@@ -78,7 +78,23 @@ namespace Microsoft.Extensions.DependencyInjection
                            .CompileScss(options)
                            .FingerprintUrls()
                            .AddResponseHeader("X-Content-Type-Options", "nosniff")
-                           .MinifyCss();
+                           .minifyCssWithOptions(options);
+        }
+
+        private static IEnumerable<IAsset> minifyCssWithOptions(this IEnumerable<IAsset> assets, WebOptimazerScssOptions options)
+        {
+            if (options?.MinifyCss ?? true)
+                return assets.MinifyCss();
+            else
+                return assets;
+        }
+
+        private static IAsset minifyCssWithOptions(this IAsset asset, WebOptimazerScssOptions options)
+        {
+            if (options?.MinifyCss ?? true)
+                return asset.MinifyCss();
+            else
+                return asset;
         }
     }
 }

--- a/src/WebOptimazerScssOptions.cs
+++ b/src/WebOptimazerScssOptions.cs
@@ -92,5 +92,10 @@ namespace WebOptimizer.Sass
         /// Gets or sets a dynamic delegate used to resolve imports dynamically.
         /// </summary>
         public TryImportDelegate TryImport { get; set; }
+
+        /// <summary>
+        /// Gets or sets the option to minify the resulting css.
+        /// </summary>
+        public bool MinifyCss { get; set; } = true;
     }
 }

--- a/test/WebOptimazerScssOptionsTest.cs
+++ b/test/WebOptimazerScssOptionsTest.cs
@@ -1,0 +1,15 @@
+using Xunit;
+
+namespace WebOptimizer.Sass.Test
+{
+    public class WebOptimazerScssOptionsTest
+    {
+        [Fact]
+        public void MinifyScssOptionIsTrueByDefault()
+        {
+            var target = new WebOptimazerScssOptions();
+
+            Assert.True(target.MinifyCss);
+        }
+    }
+}


### PR DESCRIPTION
Embedded generated map files were being stripped out in the minifying process.  This allows for the minification process to be enabled or disabled when using the pipeline extensions.  The default value is set to true (to minify) to honor the previous default behavior of always minifying.