### PR TITLE
Switch to Dart Sass

### DIFF
--- a/src/WebOptimazerScssOptions.cs
+++ b/src/WebOptimazerScssOptions.cs
@@ -1,8 +1,7 @@
-﻿using SharpScss;
+using DartSassHost;
 using System;
 using System.Collections.Generic;
 using System.Text;
-using static SharpScss.ScssOptions;
 
 namespace WebOptimizer.Sass
 {
@@ -14,7 +13,7 @@ namespace WebOptimizer.Sass
         public WebOptimazerScssOptions()
         {
             //Precision = 5;
-            OutputStyle = ScssOutputStyle.Nested;
+            OutputStyle = OutputStyle.Expanded;
             IncludePaths = new List<string>();
             Indent = "  ";
             Linefeed = "\n";
@@ -29,7 +28,7 @@ namespace WebOptimizer.Sass
         /// <summary>
         /// Gets or sets the output style. Default is <see cref="ScssOutputStyle.Nested"/>
         /// </summary>
-        public ScssOutputStyle OutputStyle { get; set; }
+        public OutputStyle OutputStyle { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether to generate source map (result in <see cref="ScssResult.SourceMap"/>
@@ -91,7 +90,7 @@ namespace WebOptimizer.Sass
         /// <summary>
         /// Gets or sets a dynamic delegate used to resolve imports dynamically.
         /// </summary>
-        public TryImportDelegate TryImport { get; set; }
+        //public TryImportDelegate TryImport { get; set; }
 
         /// <summary>
         /// Gets or sets the option to minify the resulting css.

--- a/src/WebOptimizer.Sass.csproj
+++ b/src/WebOptimizer.Sass.csproj
@@ -1,27 +1,33 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-     <TargetFramework>netcoreapp3.0</TargetFramework>
-      <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\WebOptimizer.Sass.xml</DocumentationFile>
-      <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-      <PackageTags>sass, scss, bundle, minify, optimize, asp.net core</PackageTags>
-      <Version>3.0.0</Version>
-      <Authors>LigerShark</Authors>
-      <Company>LigerShark</Company>
-      <Description>Compiles Sass and Scss files for the LigerShark.WebOptimizer.Core system.</Description>
-      <Copyright>Copyright © LigerShark</Copyright>
-      <PackageId>LigerShark.WebOptimizer.Sass</PackageId>
-      <Product>LigerShark.WebOptimizer.Sass</Product>
-      <PackageIconUrl>https://raw.githubusercontent.com/ligershark/WebOptimizer/master/art/logo64x64.png</PackageIconUrl>
-      <PackageProjectUrl>https://github.com/ligershark/WebOptimizer.Sass</PackageProjectUrl>
-      <PackageLicenseUrl>https://github.com/ligershark/WebOptimizer.Sass/blob/master/LICENSE.txt</PackageLicenseUrl>
-      <RepositoryUrl>https://github.com/ligershark/WebOptimizer.Sass</RepositoryUrl>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>netcoreapp3.0</TargetFramework>
+		<DocumentationFile>bin\$(Configuration)\$(TargetFramework)\WebOptimizer.Sass.xml</DocumentationFile>
+		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+		<PackageTags>sass, scss, bundle, minify, optimize, asp.net core</PackageTags>
+		<Version>3.0.0</Version>
+		<Authors>LigerShark</Authors>
+		<Company>LigerShark</Company>
+		<Description>Compiles Sass and Scss files for the LigerShark.WebOptimizer.Core system.</Description>
+		<Copyright>Copyright © LigerShark</Copyright>
+		<PackageId>LigerShark.WebOptimizer.Sass</PackageId>
+		<Product>LigerShark.WebOptimizer.Sass</Product>
+		<PackageIconUrl>https://raw.githubusercontent.com/ligershark/WebOptimizer/master/art/logo64x64.png</PackageIconUrl>
+		<PackageProjectUrl>https://github.com/ligershark/WebOptimizer.Sass</PackageProjectUrl>
+		<PackageLicenseUrl>https://github.com/ligershark/WebOptimizer.Sass/blob/master/LICENSE.txt</PackageLicenseUrl>
+		<RepositoryUrl>https://github.com/ligershark/WebOptimizer.Sass</RepositoryUrl>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="LigerShark.WebOptimizer.Core" Version="3.0.276" />
-    <PackageReference Include="SharpScss" Version="2.0.0" />
-  </ItemGroup>
-
+	<ItemGroup>
+		<FrameworkReference Include="Microsoft.AspNetCore.App" />
+		<PackageReference Include="JavaScriptEngineSwitcher.ChakraCore" Version="3.12.6" />
+		<PackageReference Include="JavaScriptEngineSwitcher.ChakraCore.Native.win-x64" Version="3.12.6" />
+		<PackageReference Include="JavaScriptEngineSwitcher.ChakraCore.Native.win-x86" Version="3.12.6"  />
+		<PackageReference Include="JavaScriptEngineSwitcher.ChakraCore.Native.win-arm" Version="3.12.6" />
+		<PackageReference Include="JavaScriptEngineSwitcher.ChakraCore.Native.win-arm64" Version="3.12.6" />
+		<PackageReference Include="JavaScriptEngineSwitcher.ChakraCore.Native.linux-x64" Version="3.12.6"  />
+		<PackageReference Include="JavaScriptEngineSwitcher.ChakraCore.Native.osx-x64" Version="3.12.6" />
+		<PackageReference Include="LigerShark.WebOptimizer.Core" Version="3.0.276" />
+		<PackageReference Include="DartSassHost" Version="1.0.0-preview4" />
+	</ItemGroup>
 </Project>

--- a/test/CompilerTest.cs
+++ b/test/CompilerTest.cs
@@ -46,7 +46,7 @@ namespace WebOptimizer.Sass.Test
 
             await processor.ExecuteAsync(context.Object);
             var result = context.Object.Content.First().Value;
-            Assert.Equal("div {\n  background: blue; }\n", result.AsString());
+            Assert.Equal("div {\n  background: blue;\n}", result.AsString());
         }
 
         [Fact]


### PR DESCRIPTION
Libsass is now officially deprecated as of october 2020 (https://sass-lang.com/blog/libsass-is-deprecated), and had not recieved support for any new language features since november 2018. 

This switch will bring the last 3 years of sass improvements to users, including the use of sass modules (fixes #29) 

It seems that libsass was outputting the closing brace on the same line as the last member of the block, with a trailing newline, whereas dartsass now puts the closing brace on its own line, with no trailing new line, the tests have been updated to reflect this.

Since DartSass is compiled down to javascript, this also required a javascript engine as a depenedency, this is accomplished with https://github.com/Taritsyn/JavaScriptEngineSwitcher and their ChakraCore packages. The chakra core packages could be removed, requiring consumers of this library to register a default Javascript engine with JavaScriptEngineSwitcher, which the dartsass wrapper would make use of.

I have made a best effort attempt at mapping the existing WebOptimazerScssOptions that were based on SharpScss.ScssOptions to their equivelant DartSassHost.CompilationOptions. 

I am willing to make any changes needed to this PR, just let me know.
