### PR TITLE
Reduce excessive memory consumption when using the Dart Sass Host library

### DIFF
--- a/src/WebOptimizer.Sass.csproj
+++ b/src/WebOptimizer.Sass.csproj
@@ -22,12 +22,12 @@
 		<FrameworkReference Include="Microsoft.AspNetCore.App" />
 		<PackageReference Include="JavaScriptEngineSwitcher.ChakraCore" Version="3.12.6" />
 		<PackageReference Include="JavaScriptEngineSwitcher.ChakraCore.Native.win-x64" Version="3.12.6" />
-		<PackageReference Include="JavaScriptEngineSwitcher.ChakraCore.Native.win-x86" Version="3.12.6"  />
+		<PackageReference Include="JavaScriptEngineSwitcher.ChakraCore.Native.win-x86" Version="3.12.6" />
 		<PackageReference Include="JavaScriptEngineSwitcher.ChakraCore.Native.win-arm" Version="3.12.6" />
 		<PackageReference Include="JavaScriptEngineSwitcher.ChakraCore.Native.win-arm64" Version="3.12.6" />
-		<PackageReference Include="JavaScriptEngineSwitcher.ChakraCore.Native.linux-x64" Version="3.12.6"  />
+		<PackageReference Include="JavaScriptEngineSwitcher.ChakraCore.Native.linux-x64" Version="3.12.6" />
 		<PackageReference Include="JavaScriptEngineSwitcher.ChakraCore.Native.osx-x64" Version="3.12.6" />
 		<PackageReference Include="LigerShark.WebOptimizer.Core" Version="3.0.276" />
-		<PackageReference Include="DartSassHost" Version="1.0.0-preview4" />
+		<PackageReference Include="DartSassHost" Version="1.0.0-preview5" />
 	</ItemGroup>
 </Project>


### PR DESCRIPTION
Initialization of the Sass compiler is a rather resource-intensive operation, so you should reuse an existing instances whenever possible.

Most JS engines compatible with the Dart Sass Host library use unmanaged resources, so you should always explicitly call the `Dispose` method of the Sass compiler. Otherwise, JS engine instances will be added to the finalization queue.