### PR TITLE
Update Compiler.cs

### DIFF
--- a/src/Compiler.cs
+++ b/src/Compiler.cs
@@ -136,7 +136,12 @@ namespace WebOptimizer.Sass
                     }
                 }
             }
-
+            
+            _addedImports.ForEach(filePath =>
+            {
+                cacheKey.Append(_fileVersionProvider.AddFileVersionToPath(filePath));
+            });
+            
             using var algo = SHA1.Create();
             byte[] buffer = Encoding.UTF8.GetBytes(cacheKey.ToString());
             byte[] hash = algo.ComputeHash(buffer);
@@ -173,8 +178,7 @@ namespace WebOptimizer.Sass
 
             // Add file in cache key
             _addedImports.Add(filePath);
-            cacheKey.Append(_fileVersionProvider.AddFileVersionToPath(filePath));
-
+            
             // Add sub files
             using var stream = file.CreateReadStream();
             using var reader = new StreamReader(stream);


### PR DESCRIPTION
Generates the cache key at the end after parsing all the files, if files have been previously parsed to still include them for the generated cacheKey. 

seems to behave as expected when changing file partials back generating a unique key based on the contained bytedata, when change back previous keys are utilized as would be expected of content caching.

This may not be an entire fix, maybe just a partial fixed for me locally would like someone to additionally test it if possible.

Seems to fix #24 during my local testing with MemoryCache only and enableTagHelperBundling as true