### PR TITLE
Update Compiler.cs

### DIFF
--- a/src/Compiler.cs
+++ b/src/Compiler.cs
@@ -137,10 +137,9 @@ namespace WebOptimizer.Sass
                 }
             }
             
-            _addedImports.ForEach(filePath =>
-            {
-                cacheKey.Append(_fileVersionProvider.AddFileVersionToPath(filePath));
-            });
+            for (int i = 0; i < _addedImports.Count; i++) {
+                cacheKey.Append(_fileVersionProvider.AddFileVersionToPath(_addedImports[i]));
+            }
             
             using var algo = SHA1.Create();
             byte[] buffer = Encoding.UTF8.GetBytes(cacheKey.ToString());


### PR DESCRIPTION
- This fixes the exception:
   `System.InvalidOperationException: 'Collection was modified; enumeration operation may not execute.'`

This occurs in cases where multiple requests for the same file occurs, via different threads as both could be running the `AppendImportedSassFiles` function and adding files at different states, where one has exited while the other is still processing because the short-circuiting of previously appended files to the `_addedImports` variable.

There is still a chance that when there are multiple request occurring in tandem that the 2nd request will exit first with a different key, without an exception but I haven't been able to reproduce it in my testing, to fix this there needs to be some sort of locking mechanism that allows the processing to occur only on a single thread while holding the other threads up, as a possible approach.