### PR TITLE
Switched to using the JavaScriptEngineSwitcher.V8, which supports more platforms

### DIFF
--- a/src/Compiler.cs
+++ b/src/Compiler.cs
@@ -12,7 +12,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Extensions.Caching.Memory;
 using DartSassHost;
-using JavaScriptEngineSwitcher.ChakraCore;
+using JavaScriptEngineSwitcher.V8;
 
 namespace WebOptimizer.Sass
 {
@@ -74,7 +74,7 @@ namespace WebOptimizer.Sass
                 //settings.TryImport = options.TryImport;
             }
 
-            using (var sassCompiler = new SassCompiler(new ChakraCoreJsEngineFactory(), settings))
+            using (var sassCompiler = new SassCompiler(new V8JsEngineFactory(), settings))
             {
                 foreach (string route in context.Content.Keys)
                 {

--- a/src/WebOptimizer.Sass.csproj
+++ b/src/WebOptimizer.Sass.csproj
@@ -20,14 +20,16 @@
 
 	<ItemGroup>
 		<FrameworkReference Include="Microsoft.AspNetCore.App" />
-		<PackageReference Include="JavaScriptEngineSwitcher.ChakraCore" Version="3.12.6" />
-		<PackageReference Include="JavaScriptEngineSwitcher.ChakraCore.Native.win-x64" Version="3.12.6" />
-		<PackageReference Include="JavaScriptEngineSwitcher.ChakraCore.Native.win-x86" Version="3.12.6" />
-		<PackageReference Include="JavaScriptEngineSwitcher.ChakraCore.Native.win-arm" Version="3.12.6" />
-		<PackageReference Include="JavaScriptEngineSwitcher.ChakraCore.Native.win-arm64" Version="3.12.6" />
-		<PackageReference Include="JavaScriptEngineSwitcher.ChakraCore.Native.linux-x64" Version="3.12.6" />
-		<PackageReference Include="JavaScriptEngineSwitcher.ChakraCore.Native.osx-x64" Version="3.12.6" />
 		<PackageReference Include="DartSassHost" Version="1.0.0-preview5" />
+		<PackageReference Include="JavaScriptEngineSwitcher.V8" Version="3.17.1" />
 		<PackageReference Include="LigerShark.WebOptimizer.Core" Version="3.0.348" />
+		<PackageReference Include="Microsoft.ClearScript.V8.Native.linux-arm" Version="7.2.1" />
+		<PackageReference Include="Microsoft.ClearScript.V8.Native.linux-arm64" Version="7.2.1" />
+		<PackageReference Include="Microsoft.ClearScript.V8.Native.linux-x64" Version="7.2.1" />
+		<PackageReference Include="Microsoft.ClearScript.V8.Native.osx-arm64" Version="7.2.1" />
+		<PackageReference Include="Microsoft.ClearScript.V8.Native.osx-x64" Version="7.2.1" />
+		<PackageReference Include="Microsoft.ClearScript.V8.Native.win-arm64" Version="7.2.1" />
+		<PackageReference Include="Microsoft.ClearScript.V8.Native.win-x64" Version="7.2.1" />
+		<PackageReference Include="Microsoft.ClearScript.V8.Native.win-x86" Version="7.2.1" />
 	</ItemGroup>
 </Project>

--- a/test/WebOptimizer.Sass.Test.csproj
+++ b/test/WebOptimizer.Sass.Test.csproj
@@ -7,6 +7,15 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="JavaScriptEngineSwitcher.V8" Version="3.17.1" />
+    <PackageReference Include="Microsoft.ClearScript.V8.Native.linux-arm" Version="7.2.1" />
+    <PackageReference Include="Microsoft.ClearScript.V8.Native.linux-arm64" Version="7.2.1" />
+    <PackageReference Include="Microsoft.ClearScript.V8.Native.linux-x64" Version="7.2.1" />
+    <PackageReference Include="Microsoft.ClearScript.V8.Native.osx-arm64" Version="7.2.1" />
+    <PackageReference Include="Microsoft.ClearScript.V8.Native.osx-x64" Version="7.2.1" />
+    <PackageReference Include="Microsoft.ClearScript.V8.Native.win-arm64" Version="7.2.1" />
+    <PackageReference Include="Microsoft.ClearScript.V8.Native.win-x64" Version="7.2.1" />
+    <PackageReference Include="Microsoft.ClearScript.V8.Native.win-x86" Version="7.2.1" />
     <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="3.1.6" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
     <PackageReference Include="Moq" Version="4.14.5" />


### PR DESCRIPTION
Switched to the JavaScriptEngineSwitcher.V8, which allows for support to linux-arm platform as well as all other x86 and arm platforms