### PR TITLE
Update a Dart Sass Host to version 1.0.1

### DIFF
--- a/src/WebOptimizer.Sass.csproj
+++ b/src/WebOptimizer.Sass.csproj
@@ -23,16 +23,16 @@
 
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="DartSassHost" Version="1.0.0-preview5" />
-    <PackageReference Include="JavaScriptEngineSwitcher.V8" Version="3.18.4" />
+    <PackageReference Include="DartSassHost" Version="1.0.1" />
+    <PackageReference Include="JavaScriptEngineSwitcher.V8" Version="3.20.8" />
     <PackageReference Include="LigerShark.WebOptimizer.Core" Version="3.0.368" />
-    <PackageReference Include="Microsoft.ClearScript.V8.Native.linux-arm" Version="7.3.1" />
-    <PackageReference Include="Microsoft.ClearScript.V8.Native.linux-arm64" Version="7.3.1" />
-    <PackageReference Include="Microsoft.ClearScript.V8.Native.linux-x64" Version="7.3.1" />
-    <PackageReference Include="Microsoft.ClearScript.V8.Native.osx-arm64" Version="7.3.1" />
-    <PackageReference Include="Microsoft.ClearScript.V8.Native.osx-x64" Version="7.3.1" />
-    <PackageReference Include="Microsoft.ClearScript.V8.Native.win-arm64" Version="7.3.1" />
-    <PackageReference Include="Microsoft.ClearScript.V8.Native.win-x64" Version="7.3.1" />
-    <PackageReference Include="Microsoft.ClearScript.V8.Native.win-x86" Version="7.3.1" />
+    <PackageReference Include="Microsoft.ClearScript.V8.Native.linux-arm" Version="7.3.6" />
+    <PackageReference Include="Microsoft.ClearScript.V8.Native.linux-arm64" Version="7.3.6" />
+    <PackageReference Include="Microsoft.ClearScript.V8.Native.linux-x64" Version="7.3.6" />
+    <PackageReference Include="Microsoft.ClearScript.V8.Native.osx-arm64" Version="7.3.6" />
+    <PackageReference Include="Microsoft.ClearScript.V8.Native.osx-x64" Version="7.3.6" />
+    <PackageReference Include="Microsoft.ClearScript.V8.Native.win-arm64" Version="7.3.6" />
+    <PackageReference Include="Microsoft.ClearScript.V8.Native.win-x64" Version="7.3.6" />
+    <PackageReference Include="Microsoft.ClearScript.V8.Native.win-x86" Version="7.3.6" />
   </ItemGroup>
 </Project>

--- a/test/WebOptimizer.Sass.Test.csproj
+++ b/test/WebOptimizer.Sass.Test.csproj
@@ -7,15 +7,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="JavaScriptEngineSwitcher.V8" Version="3.18.4" />
-    <PackageReference Include="Microsoft.ClearScript.V8.Native.linux-arm" Version="7.3.1" />
-    <PackageReference Include="Microsoft.ClearScript.V8.Native.linux-arm64" Version="7.3.1" />
-    <PackageReference Include="Microsoft.ClearScript.V8.Native.linux-x64" Version="7.3.1" />
-    <PackageReference Include="Microsoft.ClearScript.V8.Native.osx-arm64" Version="7.3.1" />
-    <PackageReference Include="Microsoft.ClearScript.V8.Native.osx-x64" Version="7.3.1" />
-    <PackageReference Include="Microsoft.ClearScript.V8.Native.win-arm64" Version="7.3.1" />
-    <PackageReference Include="Microsoft.ClearScript.V8.Native.win-x64" Version="7.3.1" />
-    <PackageReference Include="Microsoft.ClearScript.V8.Native.win-x86" Version="7.3.1" />
     <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="3.1.6" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
     <PackageReference Include="Moq" Version="4.18.1" />


### PR DESCRIPTION
Hello!

Dart Sass Host library has recently become stable, so I recommend that you update it, as well as its dependencies, to the latest versions.