### PR TITLE
Update ImportRegex to support @use

### DIFF
--- a/src/Compiler.cs
+++ b/src/Compiler.cs
@@ -1,4 +1,4 @@
-﻿using DartSassHost;
+using DartSassHost;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.WebUtilities;
@@ -21,7 +21,7 @@ namespace WebOptimizer.Sass
     /// <seealso cref="WebOptimizer.IProcessor" />
     public class Compiler : IProcessor
     {
-        private static Regex ImportRegex = new Regex("^@import ['\"]([^\"']+)['\"];$");
+        private static Regex ImportRegex = new Regex("^@(?:import|use) ['\"]([^\"']+)['\"];$");
 
         /// <summary>
         /// Gets the custom key that should be used when calculating the memory cache key.

--- a/test/CompilerTest.cs
+++ b/test/CompilerTest.cs
@@ -99,8 +99,8 @@ namespace WebOptimizer.Sass.Test
             test3.Setup(f => f.Exists).Returns(true);
             test3.Setup(f => f.PhysicalPath).Returns("css/test3.scss");
             test3.SetupSequence(f => f.CreateReadStream())
-                .Returns(new MemoryStream(Encoding.Default.GetBytes("@import url('http://localhost/'); \r\n")))
-                .Returns(new MemoryStream(Encoding.Default.GetBytes("@import url('http://localhost/'); \r\n")));
+                .Returns(new MemoryStream(Encoding.Default.GetBytes("@import 'http://localhost/'; \r\n @use 'test5';")))
+                .Returns(new MemoryStream(Encoding.Default.GetBytes("@import 'http://localhost/'; \r\n @use 'test5';")));
 
             var test4 = new Mock<IFileInfo>();
             test4.Setup(f => f.Exists).Returns(true);
@@ -108,6 +108,20 @@ namespace WebOptimizer.Sass.Test
             test4.SetupSequence(f => f.CreateReadStream())
                 .Returns(new MemoryStream(Encoding.Default.GetBytes("@import 'http://localhost/';")))
                 .Returns(new MemoryStream(Encoding.Default.GetBytes("@import 'http://localhost/';")));
+
+            var test5 = new Mock<IFileInfo>();
+            test5.Setup(f => f.Exists).Returns(true);
+            test5.Setup(f => f.PhysicalPath).Returns("css/test5.scss");
+            test5.SetupSequence(f => f.CreateReadStream())
+                .Returns(new MemoryStream(Encoding.Default.GetBytes("@use '../test6';")))
+                .Returns(new MemoryStream(Encoding.Default.GetBytes("@use '../test6';")));
+
+            var test6 = new Mock<IFileInfo>();
+            test6.Setup(f => f.Exists).Returns(true);
+            test6.Setup(f => f.PhysicalPath).Returns("test6.scss");
+            test6.SetupSequence(f => f.CreateReadStream())
+                .Returns(new MemoryStream(Encoding.Default.GetBytes("@use 'http://localhost/';")))
+                .Returns(new MemoryStream(Encoding.Default.GetBytes("@use 'http://localhost/';")));
 
             var changeToken = new Mock<IChangeToken>();
             fileProvider.Setup(p => p.Watch(It.IsAny<string>()))
@@ -120,6 +134,10 @@ namespace WebOptimizer.Sass.Test
                 .Returns(test3.Object);
             fileProvider.Setup(p => p.GetFileInfo("test4.scss"))
                 .Returns(test4.Object);
+            fileProvider.Setup(p => p.GetFileInfo("css/test5.scss"))
+                .Returns(test5.Object);
+            fileProvider.Setup(p => p.GetFileInfo("test6.scss"))
+                .Returns(test6.Object);
 
             // Setup Cache
             var cache = new Mock<IMemoryCache>();


### PR DESCRIPTION
The @import syntax has been flagged for deprecation as of March 2023 (https://github.com/sass/sass/blob/main/accepted/module-system.md#timeline). Sass maintainers now recommend @use instead. 

I noticed that the ImportRegex did not support files that were included via @use and I've updated it accordingly. The load paths work the same for both module systems so the rest of the regex should be fine.