### PR TITLE
Make compiler compatible with embedded files

### DIFF
--- a/src/Compiler.cs
+++ b/src/Compiler.cs
@@ -86,7 +86,7 @@ namespace WebOptimizer.Sass
 
                     if (file.Exists)
                     {
-                        result = sassCompiler.CompileFile(file.PhysicalPath);
+                        result = sassCompiler.CompileFile(file.PhysicalPath ?? route);
                     }
                     else
                     {

--- a/src/Compiler.cs
+++ b/src/Compiler.cs
@@ -77,11 +77,11 @@ namespace WebOptimizer.Sass
                 settings.SourceMapRootPath = options.SourceMapRoot;
             }
 
-			IFileManager fileManager = FileManager.Instance;
-			if (fileProvider is ManifestEmbeddedFileProvider)
-			{
-				fileManager = new ManifestFileManager(fileProvider);
-			}
+            IFileManager fileManager = FileManager.Instance;
+            if (fileProvider is ManifestEmbeddedFileProvider)
+            {
+                fileManager = new ManifestFileManager(fileProvider);
+            }
 
             using (var sassCompiler = new SassCompiler(fileManager, settings))
             {

--- a/src/Compiler.cs
+++ b/src/Compiler.cs
@@ -77,7 +77,13 @@ namespace WebOptimizer.Sass
                 settings.SourceMapRootPath = options.SourceMapRoot;
             }
 
-            using (var sassCompiler = new SassCompiler(settings))
+			IFileManager fileManager = FileManager.Instance;
+			if (fileProvider is ManifestEmbeddedFileProvider)
+			{
+				fileManager = new ManifestFileManager(fileProvider);
+			}
+
+            using (var sassCompiler = new SassCompiler(fileManager, settings))
             {
                 foreach (string route in context.Content.Keys)
                 {

--- a/src/ManifestFileManager.cs
+++ b/src/ManifestFileManager.cs
@@ -1,0 +1,60 @@
+﻿using DartSassHost;
+using JavaScriptEngineSwitcher.Core.Resources;
+using Microsoft.Extensions.FileProviders;
+using System;
+using System.IO;
+using System.Text;
+
+namespace WebOptimizer.Sass
+{
+	public class ManifestFileManager : IFileManager
+	{
+		private readonly IFileProvider _fileProvider;
+
+		public ManifestFileManager(IFileProvider fileProvider)
+		{
+			_fileProvider = fileProvider;
+		}
+
+		public bool SupportsVirtualPaths => false;
+
+		public bool FileExists(string path)
+		{
+			IFileInfo file = _fileProvider.GetFileInfo(path);
+			return file.Exists;
+		}
+
+		public string GetCurrentDirectory()
+		{
+			return "";
+		}
+
+		public bool IsAppRelativeVirtualPath(string path)
+		{
+			throw new NotImplementedException();
+		}
+
+		public string ReadFile(string path)
+		{
+			if (path == null)
+			{
+				throw new ArgumentNullException(
+					nameof(path),
+					string.Format(Strings.Common_ArgumentIsNull, nameof(path))
+				);
+			}
+
+			path = path.TrimStart('/');
+			path = path.TrimStart('\\');
+			IFileInfo file = _fileProvider.GetFileInfo(path);
+			using Stream stream = file.CreateReadStream();
+			using StreamReader reader = new StreamReader(stream, Encoding.UTF8);
+			return reader.ReadToEnd();
+		}
+
+		public string ToAbsoluteVirtualPath(string path)
+		{
+			throw new NotImplementedException();
+		}
+	}
+}

--- a/src/ManifestFileManager.cs
+++ b/src/ManifestFileManager.cs
@@ -7,54 +7,54 @@ using System.Text;
 
 namespace WebOptimizer.Sass
 {
-	public class ManifestFileManager : IFileManager
-	{
-		private readonly IFileProvider _fileProvider;
+    public class ManifestFileManager : IFileManager
+    {
+        private readonly IFileProvider _fileProvider;
 
-		public ManifestFileManager(IFileProvider fileProvider)
-		{
-			_fileProvider = fileProvider;
-		}
+        public ManifestFileManager(IFileProvider fileProvider)
+        {
+            _fileProvider = fileProvider;
+        }
 
-		public bool SupportsVirtualPaths => false;
+        public bool SupportsVirtualPaths => false;
 
-		public bool FileExists(string path)
-		{
-			IFileInfo file = _fileProvider.GetFileInfo(path);
-			return file.Exists;
-		}
+        public bool FileExists(string path)
+        {
+            IFileInfo file = _fileProvider.GetFileInfo(path);
+            return file.Exists;
+        }
 
-		public string GetCurrentDirectory()
-		{
-			return "";
-		}
+        public string GetCurrentDirectory()
+        {
+            return "";
+        }
 
-		public bool IsAppRelativeVirtualPath(string path)
-		{
-			throw new NotImplementedException();
-		}
+        public bool IsAppRelativeVirtualPath(string path)
+        {
+            throw new NotImplementedException();
+        }
 
-		public string ReadFile(string path)
-		{
-			if (path == null)
-			{
-				throw new ArgumentNullException(
-					nameof(path),
-					string.Format(Strings.Common_ArgumentIsNull, nameof(path))
-				);
-			}
+        public string ReadFile(string path)
+        {
+            if (path == null)
+            {
+                throw new ArgumentNullException(
+                    nameof(path),
+                    string.Format(Strings.Common_ArgumentIsNull, nameof(path))
+                );
+            }
 
-			path = path.TrimStart('/');
-			path = path.TrimStart('\\');
-			IFileInfo file = _fileProvider.GetFileInfo(path);
-			using Stream stream = file.CreateReadStream();
-			using StreamReader reader = new StreamReader(stream, Encoding.UTF8);
-			return reader.ReadToEnd();
-		}
+            path = path.TrimStart('/');
+            path = path.TrimStart('\\');
+            IFileInfo file = _fileProvider.GetFileInfo(path);
+            using Stream stream = file.CreateReadStream();
+            using StreamReader reader = new StreamReader(stream, Encoding.UTF8);
+            return reader.ReadToEnd();
+        }
 
-		public string ToAbsoluteVirtualPath(string path)
-		{
-			throw new NotImplementedException();
-		}
-	}
+        public string ToAbsoluteVirtualPath(string path)
+        {
+            throw new NotImplementedException();
+        }
+    }
 }

--- a/src/ManifestFileManager.cs
+++ b/src/ManifestFileManager.cs
@@ -24,15 +24,10 @@ namespace WebOptimizer.Sass
             return file.Exists;
         }
 
-        public string GetCurrentDirectory()
-        {
-            return "";
-        }
+        public string GetCurrentDirectory() => string.Empty;
 
-        public bool IsAppRelativeVirtualPath(string path)
-        {
-            throw new NotImplementedException();
-        }
+        public bool IsAppRelativeVirtualPath(string path) => throw new NotImplementedException();
+
 
         public string ReadFile(string path)
         {
@@ -44,17 +39,12 @@ namespace WebOptimizer.Sass
                 );
             }
 
-            path = path.TrimStart('/');
-            path = path.TrimStart('\\');
             IFileInfo file = _fileProvider.GetFileInfo(path);
             using Stream stream = file.CreateReadStream();
             using StreamReader reader = new StreamReader(stream, Encoding.UTF8);
             return reader.ReadToEnd();
         }
 
-        public string ToAbsoluteVirtualPath(string path)
-        {
-            throw new NotImplementedException();
-        }
+        public string ToAbsoluteVirtualPath(string path) => throw new NotImplementedException();
     }
 }


### PR DESCRIPTION
Due to CompileFile requiring an input path, any fileProvider that uses embedded resources will default to null due to the use of PhysicalPath. A null-coalescing operator has been introduced with "route" as the right-hand operand to make the input more forgiving and allow embedded files with a custom file provider.