### PR TITLE
Get an instance of the JS engine switcher by using DI

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ First of all, you need to install the [JavaScriptEngineSwitcher.Extensions.MsDep
 Then you need to install one of the NuGet packages containing a JS engine provider:
 
  * [JavaScriptEngineSwitcher.ChakraCore](https://nuget.org/packages/JavaScriptEngineSwitcher.ChakraCore)
- * [JavaScriptEngineSwitcher.Jint](https://www.nuget.org/packages/JavaScriptEngineSwitcher.Jint) (prerelease versions only)
+ * [JavaScriptEngineSwitcher.Jint](https://www.nuget.org/packages/JavaScriptEngineSwitcher.Jint)
  * [JavaScriptEngineSwitcher.Msie](https://nuget.org/packages/JavaScriptEngineSwitcher.Msie) (only in the Chakra “Edge” JsRT mode)
  * [JavaScriptEngineSwitcher.V8](https://nuget.org/packages/JavaScriptEngineSwitcher.V8)
 
@@ -37,7 +37,11 @@ public void ConfigureServices(IServiceCollection services)
     services.AddMvc();
 
     // Add JavaScriptEngineSwitcher services to the services container.
-    services.AddJsEngineSwitcher(options => options.DefaultEngineName = V8JsEngine.EngineName)
+    services.AddJsEngineSwitcher(options =>
+    {
+        options.AllowCurrentProperty = false;
+        options.DefaultEngineName = V8JsEngine.EngineName;
+    })
         .AddV8()
         ;
 

--- a/sample/WebOptimizer.Sass.Sample/Startup.cs
+++ b/sample/WebOptimizer.Sass.Sample/Startup.cs
@@ -1,4 +1,3 @@
-using JavaScriptEngineSwitcher.Core;
 using JavaScriptEngineSwitcher.Extensions.MsDependencyInjection;
 using JavaScriptEngineSwitcher.V8;
 using Microsoft.AspNetCore.Builder;
@@ -16,7 +15,11 @@ namespace WebOptimizer.Sass.Sample
             services.AddRazorPages();
 
             // Add JavaScriptEngineSwitcher services to the services container.
-            services.AddJsEngineSwitcher(options => options.DefaultEngineName = V8JsEngine.EngineName)
+            services.AddJsEngineSwitcher(options =>
+            {
+                options.AllowCurrentProperty = false;
+                options.DefaultEngineName = V8JsEngine.EngineName;
+            })
                 .AddV8()
                 ;
 

--- a/sample/WebOptimizer.Sass.Sample/WebOptimizer.Sass.Sample.csproj
+++ b/sample/WebOptimizer.Sass.Sample/WebOptimizer.Sass.Sample.csproj
@@ -5,16 +5,16 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="JavaScriptEngineSwitcher.Extensions.MsDependencyInjection" Version="3.19.0" />
-    <PackageReference Include="JavaScriptEngineSwitcher.V8" Version="3.20.10" />
-    <PackageReference Include="Microsoft.ClearScript.V8.Native.linux-arm" Version="7.3.7 " />
-    <PackageReference Include="Microsoft.ClearScript.V8.Native.linux-arm64" Version="7.3.7 " />
-    <PackageReference Include="Microsoft.ClearScript.V8.Native.linux-x64" Version="7.3.7 " />
-    <PackageReference Include="Microsoft.ClearScript.V8.Native.osx-arm64" Version="7.3.7 " />
-    <PackageReference Include="Microsoft.ClearScript.V8.Native.osx-x64" Version="7.3.7 " />
-    <PackageReference Include="Microsoft.ClearScript.V8.Native.win-arm64" Version="7.3.7 " />
-    <PackageReference Include="Microsoft.ClearScript.V8.Native.win-x64" Version="7.3.7 " />
-    <PackageReference Include="Microsoft.ClearScript.V8.Native.win-x86" Version="7.3.7 " />
+    <PackageReference Include="JavaScriptEngineSwitcher.Extensions.MsDependencyInjection" Version="3.24.0" />
+    <PackageReference Include="JavaScriptEngineSwitcher.V8" Version="3.23.2" />
+    <PackageReference Include="Microsoft.ClearScript.V8.Native.linux-arm" Version="7.4.4" />
+    <PackageReference Include="Microsoft.ClearScript.V8.Native.linux-arm64" Version="7.4.4" />
+    <PackageReference Include="Microsoft.ClearScript.V8.Native.linux-x64" Version="7.4.4" />
+    <PackageReference Include="Microsoft.ClearScript.V8.Native.osx-arm64" Version="7.4.4" />
+    <PackageReference Include="Microsoft.ClearScript.V8.Native.osx-x64" Version="7.4.4" />
+    <PackageReference Include="Microsoft.ClearScript.V8.Native.win-arm64" Version="7.4.4" />
+    <PackageReference Include="Microsoft.ClearScript.V8.Native.win-x64" Version="7.4.4" />
+    <PackageReference Include="Microsoft.ClearScript.V8.Native.win-x86" Version="7.4.4" />
 
     <ProjectReference Include="..\..\src\WebOptimizer.Sass.csproj" />
   </ItemGroup>

--- a/src/Compiler.cs
+++ b/src/Compiler.cs
@@ -1,4 +1,5 @@
 using DartSassHost;
+using JavaScriptEngineSwitcher.Core;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.WebUtilities;
@@ -53,7 +54,10 @@ namespace WebOptimizer.Sass
         public Task ExecuteAsync(IAssetContext context)
         {
             var content = new Dictionary<string, byte[]>();
-            var env = (IWebHostEnvironment)context.HttpContext.RequestServices.GetService(typeof(IWebHostEnvironment));
+            var serviceProvider = context.HttpContext.RequestServices;
+            var env = (IWebHostEnvironment)serviceProvider.GetService(typeof(IWebHostEnvironment));
+            var engineSwitcher = (IJsEngineSwitcher)serviceProvider.GetService(typeof(IJsEngineSwitcher));
+
             IFileProvider fileProvider = context.Asset.GetFileProvider(env);
 
             var settings = new CompilationOptions();
@@ -83,7 +87,7 @@ namespace WebOptimizer.Sass
                 fileManager = new ManifestFileManager(fileProvider);
             }
 
-            using (var sassCompiler = new SassCompiler(fileManager, settings))
+            using (var sassCompiler = new SassCompiler(engineSwitcher.CreateDefaultEngine, fileManager, settings))
             {
                 foreach (string route in context.Content.Keys)
                 {

--- a/src/PipelineExtensions.cs
+++ b/src/PipelineExtensions.cs
@@ -112,6 +112,11 @@ namespace Microsoft.Extensions.DependencyInjection
 
         private static void CheckJsEngineRegistration()
         {
+            if (!JsEngineSwitcher.AllowCurrentProperty)
+            {
+                return;
+            }
+
             IJsEngineSwitcher engineSwitcher = JsEngineSwitcher.Current;
             if (engineSwitcher == null
                 || !engineSwitcher.EngineFactories.Any(e => e.EngineName == engineSwitcher.DefaultEngineName))

--- a/src/WebOptimizer.Sass.csproj
+++ b/src/WebOptimizer.Sass.csproj
@@ -25,7 +25,8 @@
 
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="DartSassHost" Version="1.0.1" />
+    <PackageReference Include="DartSassHost" Version="1.0.10" />
+    <PackageReference Include="JavaScriptEngineSwitcher.Core" Version="3.24.0" />
     <PackageReference Include="LigerShark.WebOptimizer.Core" Version="3.0.372" />
   </ItemGroup>
 

--- a/test/CompilerTest.cs
+++ b/test/CompilerTest.cs
@@ -46,6 +46,9 @@ namespace WebOptimizer.Sass.Test
             context.Setup(s => s.HttpContext.RequestServices.GetService(typeof(IWebHostEnvironment)))
                    .Returns(env.Object);
 
+            context.Setup(s => s.HttpContext.RequestServices.GetService(typeof(IJsEngineSwitcher)))
+                   .Returns(JsEngineSwitcher.Current);
+
             var inputFile = new PhysicalFileInfo(new FileInfo("site.css"));
 
             context.SetupGet(s => s.Asset)

--- a/test/WebOptimizer.Sass.Test.csproj
+++ b/test/WebOptimizer.Sass.Test.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="JavaScriptEngineSwitcher.Jint" Version="3.20.9-preview" />
+    <PackageReference Include="JavaScriptEngineSwitcher.Jint" Version="3.23.9" />
     <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="3.1.6" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
     <PackageReference Include="Moq" Version="4.18.1" />


### PR DESCRIPTION
Hello!

Currently, an instance of the JS engine switcher is getting by using a `JsEngineSwitcher.Current` property which is a simple implementation of the Singleton pattern. This architecture makes it much more difficult to test by using the WebApplicationFactory from ASP.NET Core testing package and [leads to errors](https://github.com/Taritsyn/JavaScriptEngineSwitcher/issues/115).

This PR solves problem by moving to standard ASP.NET Core DI.