### PR TITLE
Update target frameworks

### DIFF
--- a/src/WebOptimizer.Sass.csproj
+++ b/src/WebOptimizer.Sass.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\WebOptimizer.Sass.xml</DocumentationFile>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
@@ -21,13 +21,14 @@
     <RepositoryUrl>https://github.com/ligershark/WebOptimizer.Sass</RepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="DartSassHost" Version="1.0.13" />
     <PackageReference Include="JavaScriptEngineSwitcher.Core" Version="3.24.1" />
-    <PackageReference Include="LigerShark.WebOptimizer.Core" Version="3.0.418" />
+    <PackageReference Include="LigerShark.WebOptimizer.Core" Version="3.0.426" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/WebOptimizer.Sass.Test.csproj
+++ b/test/WebOptimizer.Sass.Test.csproj
@@ -8,7 +8,6 @@
 
   <ItemGroup>
     <PackageReference Include="JavaScriptEngineSwitcher.Jint" Version="3.27.0" />
-    <PackageReference Include="LigerShark.WebOptimizer.Core" Version="3.0.418" />
     <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="Moq" Version="4.20.70" />


### PR DESCRIPTION
After https://github.com/ligershark/WebOptimizer/pull/322 gets merged, NET 6 support can be restored.